### PR TITLE
Included priority nodes for iteration in BFS

### DIFF
--- a/clrs/_src/algorithms/graphs.py
+++ b/clrs/_src/algorithms/graphs.py
@@ -195,6 +195,7 @@ def bfs(A: _Array, s: int) -> _Out:
   reach = np.zeros(A.shape[0])
   pi = np.arange(A.shape[0])
   reach[s] = 1
+  priority = [s]
   while True:
     prev_reach = np.copy(reach)
     probing.push(
@@ -204,12 +205,15 @@ def bfs(A: _Array, s: int) -> _Out:
             'reach_h': np.copy(prev_reach),
             'pi_h': np.copy(pi)
         })
-    for i in range(A.shape[0]):
+    priority_new = []
+    for i in priority + list(set(range(A.shape[0])) - set(priority)):
       for j in range(A.shape[0]):
         if A[i, j] > 0 and prev_reach[i] == 1:
           if pi[j] == j and j != s:
             pi[j] = i
           reach[j] = 1
+          priority_new.append(j)
+    priority = priority_new
     if np.all(reach == prev_reach):
       break
 


### PR DESCRIPTION
**Objective:** This pull request aims to discuss and potentially fix what seems to be an inconsistency in the BFS algorithm's node iteration.

While working with the BFS dataset, I stumbled upon some unexpected results. Here's an example:
```
>>> train_set = clrs.create_dataset(folder='...', algorithm='bfs', split='train', batch_size=16)[0]
>>> next(iter(train_set.as_numpy_iterator())).outputs[0].data[15]
array([0, 8, 7, 8, 7, 0, 7, 8, 0, 0, 9, 9, 5, 5, 8, 9])
```
However, when referring to the BFS description in [1], we should expect:
```
array([0, 8, 12, 8, 12, 0, 13, 8, 0, 0, 9, 9, 5, 5, 8, 9])
```
The cause of this discrepancy is that the current BFS implementation iterates over nodes in ascending order by node ID, while it should visit nodes based on the order of their discovery. The suggested fix involves incorporating a priority list for the first loop, ensuring nodes are processed in the correct order. 

I did think about other approaches, like using a queue instead of a for loop, but they seemed to change the number of iterations, potentially affecting the hints. The suggested change does not change the number of iterations and has little added overhead.

[1] Cormen, Thomas H., et al. Introduction to algorithms. MIT press, 2009.