### PR TITLE
Adding huggingface generators for clrs text

### DIFF
--- a/clrs/_src/clrs_text/huggingface_generators.py
+++ b/clrs/_src/clrs_text/huggingface_generators.py
@@ -1,0 +1,104 @@
+"""Functions to allow for Huggingface Intergration"""
+from typing import List, Dict
+from clrs import build_sampler
+from clrs._src.clrs_text.clrs_utils import format_clrs_example
+import itertools
+
+
+def clrs_gen(algs: Dict[str, List[int]], num_samples: int, seed: int = 0, use_hints: bool = True):
+    """
+    Huggingface datasets.Dataset compatible generator function for creating a dataset of fixed size
+
+    Example usage:
+        import datasets
+        algs = {"insertion_sort": [16]}
+        ds = datasets.Dataset.from_generator(clrs_gen, gen_kwargs={"algs": algs, "num_samples": 100})
+
+    Huggingface reference:
+        https://huggingface.co/docs/datasets/v2.19.0/en/package_reference/main_classes#datasets.Dataset.from_generator
+
+    Args:
+        algs (Dict[str, List[int]]): keys = algorithm names [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()], values = list of lengths required for that algorithm
+        num_samples (int): The size of the output dataset
+        seed (int), default=0: The random seed for all of the generators
+        use_hints (bool), default=True: Whether to include hints in the questions
+ 
+    Returns:
+        Sample question and answer as a dictionary
+    """
+    choices = {}
+
+    # make all of the possible generators
+    for alg in algs.keys():
+        for length in algs[alg]:
+            sampler, _ = build_sampler(
+                alg,
+                seed=seed,
+                num_samples=-1,
+                length=length,
+                track_max_steps=False,
+                use_padding=False,
+            )
+            choices[f"{alg}={length}"] = sampler
+
+    keys = itertools.cycle(list(choices.keys())) # make a cyclic list of all the generators
+
+    # uniformly sample one element from each sampler in the list up to the maximum
+    for _ in range(num_samples):
+        sampler_name = next(keys)
+        sample = choices[sampler_name].next(batch_size=1) # get one sample from the sampler
+        question, answer = format_clrs_example(
+                                sampler_name.split('=')[0], # algorithm name, split at = sign
+                                sample,
+                                use_hints=use_hints,
+                            )
+        yield {"question": question, "answer": answer}
+
+
+def clrs_gen_inf(algs: Dict[str, List[int]], seed: int = 0, use_hints: bool = True):
+    """
+    Huggingface datasets.IterableDataset compatible generator function for creating a dataset of infinite size
+
+    Example usage:
+        import datasets
+        algs = {"insertion_sort": [16]}
+        ds = datasets.IterableDataset.from_generator(clrs_gen_inf, features=datasets.Features({'question': datasets.Value(dtype='string', id=None), 'answer': datasets.Value(dtype='string', id=None)}), gen_kwargs={"algs": algs}
+
+    Huggingface reference:
+        https://huggingface.co/docs/datasets/v2.7.0/en/package_reference/main_classes#datasets.IterableDataset.from_generator
+
+    Args:
+        algs (Dict[str, List[int]]): keys = algorithm names [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()], values = list of lengths required for that algorithm
+        seed (int), default=0: The random seed for all of the generators
+        use_hints (bool), default=True: Whether to include hints in the questions
+ 
+    Returns:
+        Sample question and answer as a dictionary
+    """
+    choices = {}
+    
+    # make all of the possible generators
+    for alg in algs.keys():
+        for length in algs[alg]:
+            sampler, _ = build_sampler(
+                alg,
+                seed=seed,
+                num_samples=-1,
+                length=length,
+                track_max_steps=False,
+                use_padding=False,
+            )
+            choices[f"{alg}={length}"] = sampler
+
+    keys = itertools.cycle(list(choices.keys())) # make a cyclic list of all the generators
+
+    # uniformly sample one element from each sampler in the list continuously
+    while True:
+        sampler_name = next(keys)
+        sample = choices[sampler_name].next(batch_size=1) # get one sample from the sampler
+        question, answer = format_clrs_example(
+                                sampler_name.split('=')[0], # algorithm name, split at = sign
+                                sample,
+                                use_hints=use_hints,
+                            )
+        yield {"question": question, "answer": answer}

--- a/clrs/_src/clrs_text/huggingface_generators.py
+++ b/clrs/_src/clrs_text/huggingface_generators.py
@@ -1,10 +1,10 @@
 """Functions to allow for Huggingface Intergration."""
 
-from typing import List, Dict, Optional
 import random
+from typing import Dict, List, Optional
 
-from clrs import build_sampler
-from clrs._src.clrs_text.clrs_utils import format_clrs_example
+import clrs
+from clrs._src.clrs_text import clrs_utils
 
 
 def clrs_generator(
@@ -13,90 +13,99 @@ def clrs_generator(
     use_hints: bool = False,
     seed: int = 0,
 ):
-    """
-    Huggingface datasets.Dataset generator function for creating a dataset of fixed size.
+  """Huggingface compatible generator function for CLRS-text dataset.
 
-    Example usage for a finite dataset:
-        import datasets
-        algos_and_lengths = {"insertion_sort": [16]}
-        ds = datasets.Dataset.from_generator(
-            clrs_gen, gen_kwargs={"algos_and_lengths": algos_and_lengths, "num_samples": 100}
-        )
-
-    Example usage for infinite dataset:
-        import datasets
-        algos_and_lengths = {"insertion_sort": [16]}
-        ds = IterableDataset.from_generator(
-            clrs_infinite_generator,
-            features=Features(
-                {
-                    "text": Value(dtype="string", id=None),
-                    "question": Value(dtype="string", id=None),
-                    "answer": Value(dtype="string", id=None),
-                    "algo_name": Value(dtype="string", id=None),
-                    "length": Value(dtype="int32", id=None),
-                    "use_hints": Value(dtype="bool_", id=None),
-                }
-            ),
-            gen_kwargs={"algos_and_lengths": algos_and_lengths},
-        )
-        # features is an optional argument but can be included for better integration
-        # with huggingface.
-
-    Huggingface references:
-        https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.Dataset.from_generator
-        https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.IterableDataset.from_generator
-
-    Args:
-        algos_and_lengths: keys = algorithm names
-            [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()],
-            values = list of lengths required for that algorithm.
-        num_samples: The size of the output dataset,
-            if None the output dataset will be infitnite to be used with
-            IterableDataset.from_generator.
-        use_hints: Whether hints should be included in the question and answer.
-        seed: The random seed for all of the generators.
-
-    Returns:
-        Sample question and answer in various formats with meta data as a dictionary.
-    """
-    clrs_samplers = []
-
-    # make all of the possible generators.
-    for algo_name, lengths in algos_and_lengths.items():
-        for length in lengths:
-            sampler, _ = build_sampler(
-                algo_name,
-                seed=seed,
-                num_samples=-1,
-                length=length,
-                track_max_steps=False,
-                use_padding=False,
-            )
-            clrs_samplers.append((sampler, algo_name, length))
-
-    random.seed(seed)
-
-    infinte_switch = num_samples is None
-    sample_count = 0
-
-    # uniformly sample one element from each sampler in the list up to the maximum.
-    while infinte_switch or sample_count < num_samples:
-        sampler, algo_name, length = random.choice(clrs_samplers)
-        sample = sampler.next(batch_size=1)  # get one sample from the sampler.
-        question, answer = format_clrs_example(
-            algo_name,
-            sample,
-            use_hints=use_hints,
-        )
-
-        text = question + answer  # concatenating the question and answer.
-        sample_count += 1
-        yield {
-            "text": text,
-            "question": question,
-            "answer": answer,
-            "algo_name": algo_name,
-            "length": length,
-            "use_hints": use_hints,
+  Example usage for a finite dataset:
+    algos_and_lengths = {"insertion_sort": [16]}
+    ds = datasets.Dataset.from_generator(
+        clrs_gen, gen_kwargs={
+            "algos_and_lengths": algos_and_lengths,
+            "num_samples": 100
         }
+  )
+
+  Example usage for infinite dataset:
+    algos_and_lengths = {"insertion_sort": [16]}
+    ds = IterableDataset.from_generator(
+        clrs_generator,
+        features=Features(
+            {
+                "text": Value(dtype="string", id=None),
+                "question": Value(dtype="string", id=None),
+                "answer": Value(dtype="string", id=None),
+                "algo_name": Value(dtype="string", id=None),
+                "length": Value(dtype="int32", id=None),
+                "use_hints": Value(dtype="bool_", id=None),
+            }
+        ),
+        gen_kwargs={"algos_and_lengths": algos_and_lengths},
+    )
+    # features is an optional argument but can be included for better
+    # integration with huggingface.
+
+
+  Huggingface references:
+    - https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.Dataset.from_generator  # pylint: disable=line-too-long
+    - https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.IterableDataset.from_generator  # pylint: disable=line-too-long
+
+  Args:
+    algos_and_lengths: keys = algorithm names
+        [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()],
+        values = list of lengths required for that algorithm.
+    num_samples: The size of the output dataset,
+        if None the output dataset will be infinite to be used with
+        IterableDataset.from_generator.
+    use_hints: Whether hints should be included in the question and answer.
+    seed: The random seed for all of the generators.
+
+  Yields:
+    A dictionary with the following keys:
+        text: The question and answer concatenated.
+        question: The question from the CLRS-text dataset.
+        answer: The correct output for the given algorithm question.
+        algo_name: The name of the algorithm.
+        length: The length of the input.
+        use_hints: Whether hints were used.
+  """
+  clrs_samplers = []
+
+  # make all of the possible generators.
+  for algo_name, lengths in algos_and_lengths.items():
+    for length in lengths:
+      sampler, _ = clrs.build_sampler(
+          algo_name,
+          seed=seed,
+          num_samples=-1,
+          length=length,
+          track_max_steps=False,
+          use_padding=False,
+      )
+      clrs_samplers.append((sampler, algo_name, length))
+
+  random.seed(seed)
+
+  # num_samples is set to None for infinite generator.
+  infinite_loop = num_samples is None
+  sample_count = 0
+
+  while infinite_loop or sample_count < num_samples:
+    sampler, algo_name, length = random.choice(clrs_samplers)
+    sample = sampler.next(batch_size=1)  # get one sample from the sampler.
+    question, answer = clrs_utils.format_clrs_example(
+        algo_name,
+        sample,
+        use_hints=use_hints,
+    )
+
+    # There is no added separator between the question and answer because the
+    # question ends with a newline.
+    text = question + answer
+    sample_count += 1
+    yield {
+        "text": text,
+        "question": question,
+        "answer": answer,
+        "algo_name": algo_name,
+        "length": length,
+        "use_hints": use_hints,
+    }

--- a/clrs/_src/clrs_text/huggingface_generators.py
+++ b/clrs/_src/clrs_text/huggingface_generators.py
@@ -1,4 +1,18 @@
-"""Functions to allow for Huggingface Intergration."""
+# Copyright 2024 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Functions to allow for Huggingface Integration."""
 
 import random
 from typing import Dict, List, Optional

--- a/clrs/_src/clrs_text/huggingface_generators.py
+++ b/clrs/_src/clrs_text/huggingface_generators.py
@@ -1,122 +1,147 @@
 """Functions to allow for Huggingface Intergration"""
+
 from typing import List, Dict
+import random
+
 from clrs import build_sampler
 from clrs._src.clrs_text.clrs_utils import format_clrs_example
-import itertools
 
 
-def clrs_generator(algos_and_lengths: Dict[str, List[int]], num_samples: int, seed: int = 0, use_hints: bool = True, pretrain: bool = False):
+def clrs_generator(
+    algos_and_lengths: Dict[str, List[int]],
+    num_samples: int,
+    use_hints: bool = False,
+    seed: int = 0,
+):
     """
-    Huggingface datasets.Dataset compatible generator function for creating a dataset of fixed size
+    Huggingface datasets.Dataset generator function for creating a dataset of fixed size
 
     Example usage:
         import datasets
-        algs = {"insertion_sort": [16]}
-        ds = datasets.Dataset.from_generator(clrs_gen, gen_kwargs={"algs": algs, "num_samples": 100})
+        algos_and_lengths = {"insertion_sort": [16]}
+        ds = datasets.Dataset.from_generator(
+            clrs_gen, gen_kwargs={"algos_and_lengths": algos_and_lengths, "num_samples": 100}
+        )
 
     Huggingface reference:
         https://huggingface.co/docs/datasets/v2.19.0/en/package_reference/main_classes#datasets.Dataset.from_generator
 
     Args:
-        algs (Dict[str, List[int]]): keys = algorithm names [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()], values = list of lengths required for that algorithm
-        num_samples (int): The size of the output dataset
-        seed (int), default=0: The random seed for all of the generators
-        use_hints (bool), default=True: Whether to include hints in the questions
-        pretrain (bool), default=False: Whether to combine the question and answer into one field called text
- 
+        algos_and_lengths: keys = algorithm names
+            [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()],
+            values = list of lengths required for that algorithm
+        num_samples: The size of the output dataset
+        use_hints: Whether hints should be included in the question and answer
+        seed: The random seed for all of the generators
+
     Returns:
-        Sample question and answer as a dictionary
+        Sample question and answer in various formats with meta data as a dictionary
     """
-    choices = {}
+    clrs_samplers = []
 
     # make all of the possible generators
     for algo_name, lengths in algos_and_lengths.items():
         for length in lengths:
             sampler, _ = build_sampler(
-                alg,
+                algo_name,
                 seed=seed,
                 num_samples=-1,
                 length=length,
                 track_max_steps=False,
                 use_padding=False,
             )
-            choices[f"{alg}={length}"] = sampler
+            clrs_samplers.append((sampler, algo_name, length))
 
-    keys = itertools.cycle(list(choices.keys())) # make a cyclic list of all the generators
-
+    random.seed(seed)
     # uniformly sample one element from each sampler in the list up to the maximum
     for _ in range(num_samples):
-        sampler_name = next(keys)
-        sample = choices[sampler_name].next(batch_size=1) # get one sample from the sampler
-        algorithm_name = sampler_name.split('=')[0] # algorithm name, split at = sign
-        algorithm_size = sampler_name.split('=')[1]
+        sampler, algo_name, length = random.choice(clrs_samplers)
+        sample = sampler.next(batch_size=1)  # get one sample from the sampler
         question, answer = format_clrs_example(
-                                algorithm_name,
-                                sample,
-                                use_hints=use_hints,
-                            )
-        if pretrain:
-            text = question + answer
-            yield {"text": text, "name": algorithm_name, "size": algorithm_size}
-        else:
-            yield {"question": question, "answer": answer, "name": algorithm_name, "size": algorithm_size}
+            algo_name,
+            sample,
+            use_hints=use_hints,
+        )
+
+        text = question + answer
+        yield {
+            "text": text,
+            "question": question,
+            "answer": answer,
+            "algo_name": algo_name,
+            "length": length,
+            "use_hints": use_hints,
+        }
 
 
-def clrs_gen_inf(algs: Dict[str, List[int]], seed: int = 0, use_hints: bool = True, pretrain: bool = False):
+def clrs_infinite_generator(
+    algos_and_lengths: Dict[str, List[int]], use_hints: bool = False, seed: int = 0
+):
     """
-    Huggingface datasets.IterableDataset compatible generator function for creating a dataset of infinite size
+    Huggingface datasets.Dataset generator function for creating a dataset of fixed size
 
     Example usage:
         import datasets
-        algs = {"insertion_sort": [16]}
-        ds = datasets.IterableDataset.from_generator(clrs_gen_inf, features=datasets.Features({'question': datasets.Value(dtype='string', id=None), 'answer': datasets.Value(dtype='string', id=None)}), gen_kwargs={"algs": algs}
-        ds = IterableDataset.from_generator(clrs_gen_inf, features=Features({'question': Value(dtype='string', id=None), 'answer': Value(dtype='string', id=None), 'name': Value(dtype='string', id=None), 'size': Value(dtype='string', id=None)}), gen_kwargs={"algs": alg_lens})
-        
-        OR if using pretraining = True:
-        ds = IterableDataset.from_generator(clrs_gen_inf, features=Features({'text': Value(dtype='string', id=None), 'name': Value(dtype='string', id=None), 'size': Value(dtype='string', id=None)}), gen_kwargs={"algs": alg, "pretrain": True})
-        
+        algos_and_lengths = {"insertion_sort": [16]}
+        ds = IterableDataset.from_generator(
+            clrs_infinite_generator,
+            features=Features(
+                {
+                    "text": Value(dtype="string", id=None),
+                    "question": Value(dtype="string", id=None),
+                    "answer": Value(dtype="string", id=None),
+                    "algo_name": Value(dtype="string", id=None),
+                    "length": Value(dtype="int32", id=None),
+                    "use_hints": Value(dtype="bool_", id=None),
+                }
+            ),
+            gen_kwargs={"algos_and_lengths": algos_and_lengths},
+        )
+
     Huggingface reference:
-        https://huggingface.co/docs/datasets/v2.7.0/en/package_reference/main_classes#datasets.IterableDataset.from_generator
+        https://huggingface.co/docs/datasets/v2.19.0/en/package_reference/main_classes#datasets.Dataset.from_generator
 
     Args:
-        algs (Dict[str, List[int]]): keys = algorithm names [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()], values = list of lengths required for that algorithm
-        seed (int), default=0: The random seed for all of the generators
-        use_hints (bool), default=True: Whether to include hints in the questions
-        pretrain (bool), default=False: Whether to combine the question and answer into one field called text
- 
+        algos_and_lengths: keys = algorithm names
+            [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()],
+            values = list of lengths required for that algorithm
+        seed: The random seed for all of the generators
+
     Returns:
-        Sample question and answer as a dictionary
+        Sample question and answer in various formats with meta data as a dictionary
     """
-    choices = {}
-    
+    clrs_samplers = []
+
     # make all of the possible generators
-    for alg in algs.keys():
-        for length in algs[alg]:
+    for algo_name, lengths in algos_and_lengths.items():
+        for length in lengths:
             sampler, _ = build_sampler(
-                alg,
+                algo_name,
                 seed=seed,
                 num_samples=-1,
                 length=length,
                 track_max_steps=False,
                 use_padding=False,
             )
-            choices[f"{alg}={length}"] = sampler
+            clrs_samplers.append((sampler, algo_name, length))
 
-    keys = itertools.cycle(list(choices.keys())) # make a cyclic list of all the generators
-
-    # uniformly sample one element from each sampler in the list continuously
+    random.seed(seed)
+    # uniformly sample one element from each sampler in the list up to the maximum
     while True:
-        sampler_name = next(keys)
-        sample = choices[sampler_name].next(batch_size=1) # get one sample from the sampler
-        algorithm_name = sampler_name.split('=')[0] # algorithm name, split at = sign
-        algorithm_size = sampler_name.split('=')[1]
+        sampler, algo_name, length = random.choice(clrs_samplers)
+        sample = sampler.next(batch_size=1)  # get one sample from the sampler
         question, answer = format_clrs_example(
-                                algorithm_name,
-                                sample,
-                                use_hints=use_hints,
-                            )
-        if pretrain:
-            text = question + answer
-            yield {"text": text, "name": algorithm_name, "size": algorithm_size}
-        else:
-            yield {"question": question, "answer": answer, "name": algorithm_name, "size": algorithm_size}
+            algo_name,
+            sample,
+            use_hints=use_hints,
+        )
+
+        text = question + answer
+        yield {
+            "text": text,
+            "question": question,
+            "answer": answer,
+            "algo_name": algo_name,
+            "length": length,
+            "use_hints": use_hints,
+        }

--- a/clrs/_src/clrs_text/huggingface_generators.py
+++ b/clrs/_src/clrs_text/huggingface_generators.py
@@ -1,6 +1,6 @@
-"""Functions to allow for Huggingface Intergration"""
+"""Functions to allow for Huggingface Intergration."""
 
-from typing import List, Dict
+from typing import List, Dict, Optional
 import random
 
 from clrs import build_sampler
@@ -9,78 +9,21 @@ from clrs._src.clrs_text.clrs_utils import format_clrs_example
 
 def clrs_generator(
     algos_and_lengths: Dict[str, List[int]],
-    num_samples: int,
+    num_samples: Optional[int] = None,
     use_hints: bool = False,
     seed: int = 0,
 ):
     """
-    Huggingface datasets.Dataset generator function for creating a dataset of fixed size
+    Huggingface datasets.Dataset generator function for creating a dataset of fixed size.
 
-    Example usage:
+    Example usage for a finite dataset:
         import datasets
         algos_and_lengths = {"insertion_sort": [16]}
         ds = datasets.Dataset.from_generator(
             clrs_gen, gen_kwargs={"algos_and_lengths": algos_and_lengths, "num_samples": 100}
         )
 
-    Huggingface reference:
-        https://huggingface.co/docs/datasets/v2.19.0/en/package_reference/main_classes#datasets.Dataset.from_generator
-
-    Args:
-        algos_and_lengths: keys = algorithm names
-            [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()],
-            values = list of lengths required for that algorithm
-        num_samples: The size of the output dataset
-        use_hints: Whether hints should be included in the question and answer
-        seed: The random seed for all of the generators
-
-    Returns:
-        Sample question and answer in various formats with meta data as a dictionary
-    """
-    clrs_samplers = []
-
-    # make all of the possible generators
-    for algo_name, lengths in algos_and_lengths.items():
-        for length in lengths:
-            sampler, _ = build_sampler(
-                algo_name,
-                seed=seed,
-                num_samples=-1,
-                length=length,
-                track_max_steps=False,
-                use_padding=False,
-            )
-            clrs_samplers.append((sampler, algo_name, length))
-
-    random.seed(seed)
-    # uniformly sample one element from each sampler in the list up to the maximum
-    for _ in range(num_samples):
-        sampler, algo_name, length = random.choice(clrs_samplers)
-        sample = sampler.next(batch_size=1)  # get one sample from the sampler
-        question, answer = format_clrs_example(
-            algo_name,
-            sample,
-            use_hints=use_hints,
-        )
-
-        text = question + answer
-        yield {
-            "text": text,
-            "question": question,
-            "answer": answer,
-            "algo_name": algo_name,
-            "length": length,
-            "use_hints": use_hints,
-        }
-
-
-def clrs_infinite_generator(
-    algos_and_lengths: Dict[str, List[int]], use_hints: bool = False, seed: int = 0
-):
-    """
-    Huggingface datasets.Dataset generator function for creating a dataset of fixed size
-
-    Example usage:
+    Example usage for infinite dataset:
         import datasets
         algos_and_lengths = {"insertion_sort": [16]}
         ds = IterableDataset.from_generator(
@@ -97,22 +40,29 @@ def clrs_infinite_generator(
             ),
             gen_kwargs={"algos_and_lengths": algos_and_lengths},
         )
+        # features is an optional argument but can be included for better integration
+        # with huggingface.
 
-    Huggingface reference:
-        https://huggingface.co/docs/datasets/v2.19.0/en/package_reference/main_classes#datasets.Dataset.from_generator
+    Huggingface references:
+        https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.Dataset.from_generator
+        https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.IterableDataset.from_generator
 
     Args:
         algos_and_lengths: keys = algorithm names
             [Must be same as in clrs.CLRS_30_ALGS_SETTINGS.keys()],
-            values = list of lengths required for that algorithm
-        seed: The random seed for all of the generators
+            values = list of lengths required for that algorithm.
+        num_samples: The size of the output dataset,
+            if None the output dataset will be infitnite to be used with
+            IterableDataset.from_generator.
+        use_hints: Whether hints should be included in the question and answer.
+        seed: The random seed for all of the generators.
 
     Returns:
-        Sample question and answer in various formats with meta data as a dictionary
+        Sample question and answer in various formats with meta data as a dictionary.
     """
     clrs_samplers = []
 
-    # make all of the possible generators
+    # make all of the possible generators.
     for algo_name, lengths in algos_and_lengths.items():
         for length in lengths:
             sampler, _ = build_sampler(
@@ -126,17 +76,22 @@ def clrs_infinite_generator(
             clrs_samplers.append((sampler, algo_name, length))
 
     random.seed(seed)
-    # uniformly sample one element from each sampler in the list up to the maximum
-    while True:
+
+    infinte_switch = num_samples is None
+    sample_count = 0
+
+    # uniformly sample one element from each sampler in the list up to the maximum.
+    while infinte_switch or sample_count < num_samples:
         sampler, algo_name, length = random.choice(clrs_samplers)
-        sample = sampler.next(batch_size=1)  # get one sample from the sampler
+        sample = sampler.next(batch_size=1)  # get one sample from the sampler.
         question, answer = format_clrs_example(
             algo_name,
             sample,
             use_hints=use_hints,
         )
 
-        text = question + answer
+        text = question + answer  # concatenating the question and answer.
+        sample_count += 1
         yield {
             "text": text,
             "question": question,

--- a/clrs/_src/clrs_text/huggingface_generators.py
+++ b/clrs/_src/clrs_text/huggingface_generators.py
@@ -5,7 +5,7 @@ from clrs._src.clrs_text.clrs_utils import format_clrs_example
 import itertools
 
 
-def clrs_gen(algs: Dict[str, List[int]], num_samples: int, seed: int = 0, use_hints: bool = True, pretrain: bool = False):
+def clrs_generator(algos_and_lengths: Dict[str, List[int]], num_samples: int, seed: int = 0, use_hints: bool = True, pretrain: bool = False):
     """
     Huggingface datasets.Dataset compatible generator function for creating a dataset of fixed size
 
@@ -30,8 +30,8 @@ def clrs_gen(algs: Dict[str, List[int]], num_samples: int, seed: int = 0, use_hi
     choices = {}
 
     # make all of the possible generators
-    for alg in algs.keys():
-        for length in algs[alg]:
+    for algo_name, lengths in algos_and_lengths.items():
+        for length in lengths:
             sampler, _ = build_sampler(
                 alg,
                 seed=seed,

--- a/clrs/_src/clrs_text/huggingface_generators_test.py
+++ b/clrs/_src/clrs_text/huggingface_generators_test.py
@@ -28,7 +28,7 @@ class TestCLRSGenerator(parameterized.TestCase):
   """Check that the generator output matches the expected format."""
 
   @parameterized.product(
-      algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys())[:1],
+      algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
       lengths=[[4, 8]],
       use_hints=[True, False],
       dataset_from_generator_and_num_samples=[

--- a/clrs/_src/clrs_text/huggingface_generators_test.py
+++ b/clrs/_src/clrs_text/huggingface_generators_test.py
@@ -10,25 +10,38 @@ class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
       algo_name = list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
       lengths = [[16], [16, 32]],
       use_hints = [True, False],
+      pretrain = [False, True],
   )
-  def test_format(self, algo_name, lengths, use_hints):
+  def test_format(self, algo_name, lengths, use_hints, pretrain):
     """Test that we can format samples from any algo into strings from a hf Dataset."""
     algs = {algo_name: lengths}
-    ds = Dataset.from_generator(huggingface_generators.clrs_gen, gen_kwargs={"algs": algs, "num_samples": 100, "use_hints": use_hints})
+    ds = Dataset.from_generator(huggingface_generators.clrs_gen, gen_kwargs={"algs": algs, "num_samples": 100, "use_hints": use_hints, "pretrain": pretrain})
 
     for sample in ds:
-      question, answer = sample['question'], sample['answer']
+      if pretrain:
+        text = sample['text']
+        self.assertTrue(text.startswith(f'{algo_name}:\n'))
+        self.assertTrue(text.endswith('\n\n'))
 
-      self.assertTrue(question.startswith(f'{algo_name}:\n'))
-      self.assertTrue(question.endswith(':\n'))
-      self.assertTrue(answer.endswith('\n\n'))
+        if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+          self.assertIn('trace | ', text)
+          self.assertIn('initial_trace:', text)
+        else:
+          self.assertNotIn('trace | ', text)
+          self.assertNotIn('initial_trace:', text)
 
-      if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
-        self.assertIn('trace | ', question)
-        self.assertIn('initial_trace:', question)
-      else:
-        self.assertNotIn('trace | ', question)
-        self.assertNotIn('initial_trace:', question)
+      else: # pretrain is false
+        question, answer = sample['question'], sample['answer']
+        self.assertTrue(question.startswith(f'{algo_name}:\n'))
+        self.assertTrue(question.endswith(':\n'))
+        self.assertTrue(answer.endswith('\n\n'))
+
+        if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+          self.assertIn('trace | ', question)
+          self.assertIn('initial_trace:', question)
+        else:
+          self.assertNotIn('trace | ', question)
+          self.assertNotIn('initial_trace:', question)
 
 
 class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
@@ -37,24 +50,40 @@ class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
       algo_name = list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
       lengths = [[16], [16, 32]],
       use_hints = [True, False],
+      pretrain = [False, True],
   )
-  def test_format(self, algo_name, lengths, use_hints):
+  def test_format(self, algo_name, lengths, use_hints, pretrain):
     """Test that we can format samples from any algo into strings from a hf IterableDataset."""
     algs = {algo_name: lengths}
-    ds = IterableDataset.from_generator(huggingface_generators.clrs_gen_inf, features=Features({'question': Value(dtype='string', id=None), 'answer': Value(dtype='string', id=None)}), gen_kwargs={"algs": algs, "use_hints": use_hints})
+    if pretrain: # we have different columns in a pretrain and regular datasets, for ease of use
+      ds = IterableDataset.from_generator(huggingface_generators.clrs_gen_inf, features=Features({'text': Value(dtype='string', id=None), 'name': Value(dtype='string', id=None), 'size': Value(dtype='string', id=None)}), gen_kwargs={"algs": algs, "use_hints": use_hints, "pretrain":pretrain})
+    else:
+      ds = IterableDataset.from_generator(huggingface_generators.clrs_gen_inf, features=Features({'question': Value(dtype='string', id=None), 'answer': Value(dtype='string', id=None), 'name': Value(dtype='string', id=None), 'size': Value(dtype='string', id=None)}), gen_kwargs={"algs": algs, "use_hints": use_hints, "pretrain":pretrain})
 
     ds_iterator = iter(ds)
     for _ in range(100): # only test 100 samples as we have infinite sampling on
       sample = next(ds_iterator)
-      question, answer = sample['question'], sample['answer']
+      if pretrain:
+        text = sample['text']
+        self.assertTrue(text.startswith(f'{algo_name}:\n'))
+        self.assertTrue(text.endswith('\n\n'))
 
-      self.assertTrue(question.startswith(f'{algo_name}:\n'))
-      self.assertTrue(question.endswith(':\n'))
-      self.assertTrue(answer.endswith('\n\n'))
+        if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+          self.assertIn('trace | ', text)
+          self.assertIn('initial_trace:', text)
+        else:
+          self.assertNotIn('trace | ', text)
+          self.assertNotIn('initial_trace:', text)
 
-      if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
-        self.assertIn('trace | ', question)
-        self.assertIn('initial_trace:', question)
-      else:
-        self.assertNotIn('trace | ', question)
-        self.assertNotIn('initial_trace:', question)
+      else: # pretrain is false
+        question, answer = sample['question'], sample['answer']
+        self.assertTrue(question.startswith(f'{algo_name}:\n'))
+        self.assertTrue(question.endswith(':\n'))
+        self.assertTrue(answer.endswith('\n\n'))
+
+        if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+          self.assertIn('trace | ', question)
+          self.assertIn('initial_trace:', question)
+        else:
+          self.assertNotIn('trace | ', question)
+          self.assertNotIn('initial_trace:', question)

--- a/clrs/_src/clrs_text/huggingface_generators_test.py
+++ b/clrs/_src/clrs_text/huggingface_generators_test.py
@@ -1,147 +1,139 @@
+# Copyright 2024 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 """Tests for clrs._src.clrs_text.huggingface_generators."""
 
-from datasets import Dataset, IterableDataset, Value, Features
+import functools
 
+from absl.testing import absltest
 from absl.testing import parameterized
 import clrs
-from clrs._src.clrs_text import clrs_utils, huggingface_generators
+from clrs._src.clrs_text import clrs_utils
+from clrs._src.clrs_text import huggingface_generators
+import datasets
 
 
-class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
-    """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py."""
+class TestCLRSGenerator(parameterized.TestCase):
+  """Check that the generator output matches the expected format."""
 
-    @parameterized.product(
-        algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
-        lengths=[[16], [16, 32]],
-        use_hints=[True, False],
+  @parameterized.product(
+      algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys())[:1],
+      lengths=[[4, 8]],
+      use_hints=[True, False],
+      dataset_from_generator_and_num_samples=[
+          (
+              functools.partial(
+                  datasets.Dataset.from_generator,
+                  streaming=True,
+              ),
+              10,
+          ),
+          (datasets.IterableDataset.from_generator, None),
+      ],
+  )
+  def test_generator_output_format(
+      self,
+      algo_name,
+      lengths,
+      use_hints,
+      dataset_from_generator_and_num_samples,
+  ):
+    """Test that the output format of the generator is correct."""
+    dataset_from_generator, num_samples = dataset_from_generator_and_num_samples
+    clrs_ds = dataset_from_generator(
+        huggingface_generators.clrs_generator,
+        gen_kwargs={
+            "algos_and_lengths": {algo_name: lengths},
+            "num_samples": num_samples,
+            "use_hints": use_hints,
+            "seed": 0,
+        },
     )
-    def test_format(self, algo_name, lengths, use_hints):
-        """Test that we can format samples from any algo into strings from a hf Dataset."""
-        algos_and_lengths = {algo_name: lengths}
-        ds = Dataset.from_generator(
-            huggingface_generators.clrs_generator,
-            gen_kwargs={
-                "algos_and_lengths": algos_and_lengths,
-                "num_samples": 100,
-                "use_hints": use_hints,
-            },
+    # only test the first 10 samples.
+    for _, sample in zip(range(10), clrs_ds):
+      if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+        # question should have schema for trace if hints are used.
+        q_regex_hints = (
+            rf'^{sample["algo_name"]}:\n.*?initial_trace:.*?\ntrace \| .*?:\n$'
         )
+        # answer should have trace ('|' symbol is the identifier for that).
+        a_regex_hints = r"^[^a-zA-Z]*\|[^a-zA-Z]*\n\n$"
+        self.assertRegex(sample["question"], q_regex_hints)
+        self.assertRegex(sample["answer"], a_regex_hints)
+      else:
+        # question shouldn't have trace part (trace and initial_trace keywords).
+        q_regex = (
+            rf'^{sample["algo_name"]}:\n(?!.*?initial_trace:).*?\n'
+            r"(?!trace \| ).*?:\n$"
+        )
+        self.assertRegex(sample["question"], q_regex)
+        # answer shouldn't have trace identifier ('|' symbol) with hints off.
+        self.assertRegex(sample["answer"], r"^[^a-zA-Z\|]*\n\n$")
+      self.assertEqual(sample["question"] + sample["answer"], sample["text"])
 
-        self.assertEqual(len(ds), 100)
-
-        for sample in ds:
-            (
-                text,
-                question,
-                answer,
-                sample_algo_name,
-                sample_length,
-                use_hints,
-            ) = (
-                sample["text"],
-                sample["question"],
-                sample["answer"],
-                sample["algo_name"],
-                sample["length"],
-                sample["use_hints"],
-            )
-
-            self.assertEqual(algo_name, sample_algo_name)
-            self.assertEqual(use_hints, use_hints)
-            self.assertIn(sample_length, lengths)
-
-            self.assertTrue(question.startswith(f"{algo_name}:\n"))
-            self.assertTrue(question.endswith(":\n"))
-            self.assertTrue(answer.endswith("\n\n"))
-
-            self.assertTrue(text.startswith(f"{algo_name}:\n"))
-            self.assertTrue(text.endswith("\n\n"))
-            self.assertEqual(question + answer, text)
-
-            if (
-                use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS
-            ):  # segments intersect has no hints option.
-                self.assertIn("trace | ", question)
-                self.assertIn("initial_trace:", question)
-                self.assertIn("trace | ", text)
-                self.assertIn("initial_trace:", text)
-            else:
-                self.assertNotIn("trace | ", question)
-                self.assertNotIn("initial_trace:", question)
-                self.assertNotIn("trace | ", text)
-                self.assertNotIn("initial_trace:", text)
-
-
-class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
-    """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py."""
-
-    @parameterized.product(
-        algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
-        lengths=[[16], [16, 32]],
-        use_hints=[True, False],
+  @parameterized.product(
+      lengths=[[6], [4, 8]],
+      use_hints=[True, False],
+  )
+  def test_auxiliary_fields(self, lengths, use_hints):
+    """Test that the auxiliary fields are set correctly."""
+    algos_and_lengths = {
+        algo_name: lengths for algo_name in clrs.CLRS_30_ALGS_SETTINGS
+    }
+    clrs_ds = datasets.Dataset.from_generator(
+        huggingface_generators.clrs_generator,
+        gen_kwargs={
+            "algos_and_lengths": algos_and_lengths,
+            "num_samples": 200,
+            "use_hints": use_hints,
+            "seed": 0,
+        },
+        streaming=True,
     )
-    def test_format(self, algo_name, lengths, use_hints):
-        """Test that we can format samples from any algo into strings from a hf IterableDataset."""
-        algos_and_lengths = {algo_name: lengths}
-        ds = IterableDataset.from_generator(
-            huggingface_generators.clrs_generator,
-            features=Features(
-                {
-                    "text": Value(dtype="string", id=None),
-                    "question": Value(dtype="string", id=None),
-                    "answer": Value(dtype="string", id=None),
-                    "algo_name": Value(dtype="string", id=None),
-                    "length": Value(dtype="int32", id=None),
-                    "use_hints": Value(dtype="bool_", id=None),
-                }
-            ),
-            gen_kwargs={
-                "algos_and_lengths": algos_and_lengths,
-                "use_hints": use_hints,
-                "num_samples": None,
+    sample_lengths = set()
+    sample_algorithms = set()
+    for sample in clrs_ds:
+      sample_lengths.add(sample["length"])
+      sample_algorithms.add(sample["algo_name"])
+
+      self.assertIn(sample["length"], lengths)
+      self.assertEqual(sample["use_hints"], use_hints)
+
+    # check that all lengths and algos were sampled from.
+    self.assertSetEqual(sample_lengths, set(lengths))
+    self.assertSetEqual(sample_algorithms, set(algos_and_lengths.keys()))
+
+  @parameterized.product(num_samples=[10, 50, 100])
+  def test_dataset_size(self, num_samples):
+    """Test that the dataset size is correct."""
+    clrs_ds = datasets.Dataset.from_generator(
+        huggingface_generators.clrs_generator,
+        gen_kwargs={
+            "algos_and_lengths": {
+                "insertion_sort": [16],
+                "bfs": [8, 10],
             },
-        )
+            "num_samples": num_samples,
+            "seed": 0,
+        },
+        streaming=True,
+    )
+    ds_iterator = iter(clrs_ds)
+    for _ in range(num_samples):
+      next(ds_iterator)
+    self.assertRaises(StopIteration, next, ds_iterator)
 
-        ds_iterator = iter(ds)
-        for _ in range(100):  # only test 100 samples as we have infinite sampling on.
-            sample = next(ds_iterator)
-            (
-                text,
-                question,
-                answer,
-                sample_algo_name,
-                sample_length,
-                use_hints,
-            ) = (
-                sample["text"],
-                sample["question"],
-                sample["answer"],
-                sample["algo_name"],
-                sample["length"],
-                sample["use_hints"],
-            )
 
-            self.assertEqual(algo_name, sample_algo_name)
-            self.assertEqual(use_hints, use_hints)
-            self.assertIn(sample_length, lengths)
-
-            self.assertTrue(question.startswith(f"{algo_name}:\n"))
-            self.assertTrue(question.endswith(":\n"))
-            self.assertTrue(answer.endswith("\n\n"))
-
-            self.assertTrue(text.startswith(f"{algo_name}:\n"))
-            self.assertTrue(text.endswith("\n\n"))
-            self.assertEqual(question + answer, text)
-
-            if (
-                use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS
-            ):  # segments intersect has no hints option.
-                self.assertIn("trace | ", question)
-                self.assertIn("initial_trace:", question)
-                self.assertIn("trace | ", text)
-                self.assertIn("initial_trace:", text)
-            else:
-                self.assertNotIn("trace | ", question)
-                self.assertNotIn("initial_trace:", question)
-                self.assertNotIn("trace | ", text)
-                self.assertNotIn("initial_trace:", text)
+if __name__ == "__main__":
+  absltest.main()

--- a/clrs/_src/clrs_text/huggingface_generators_test.py
+++ b/clrs/_src/clrs_text/huggingface_generators_test.py
@@ -8,7 +8,7 @@ from clrs._src.clrs_text import clrs_utils, huggingface_generators
 
 
 class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
-    """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py"""
+    """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py."""
 
     @parameterized.product(
         algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
@@ -26,6 +26,8 @@ class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
                 "use_hints": use_hints,
             },
         )
+
+        self.assertEqual(len(ds), 100)
 
         for sample in ds:
             (
@@ -58,7 +60,7 @@ class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
 
             if (
                 use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS
-            ):  # segments intersect has no hints option
+            ):  # segments intersect has no hints option.
                 self.assertIn("trace | ", question)
                 self.assertIn("initial_trace:", question)
                 self.assertIn("trace | ", text)
@@ -71,7 +73,7 @@ class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
 
 
 class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
-    """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py"""
+    """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py."""
 
     @parameterized.product(
         algo_name=list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
@@ -82,7 +84,7 @@ class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
         """Test that we can format samples from any algo into strings from a hf IterableDataset."""
         algos_and_lengths = {algo_name: lengths}
         ds = IterableDataset.from_generator(
-            huggingface_generators.clrs_infinite_generator,
+            huggingface_generators.clrs_generator,
             features=Features(
                 {
                     "text": Value(dtype="string", id=None),
@@ -93,11 +95,15 @@ class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
                     "use_hints": Value(dtype="bool_", id=None),
                 }
             ),
-            gen_kwargs={"algos_and_lengths": algos_and_lengths, "use_hints": use_hints},
+            gen_kwargs={
+                "algos_and_lengths": algos_and_lengths,
+                "use_hints": use_hints,
+                "num_samples": None,
+            },
         )
 
         ds_iterator = iter(ds)
-        for _ in range(100):  # only test 100 samples as we have infinite sampling on
+        for _ in range(100):  # only test 100 samples as we have infinite sampling on.
             sample = next(ds_iterator)
             (
                 text,
@@ -129,7 +135,7 @@ class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
 
             if (
                 use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS
-            ):  # segments intersect has no hints option
+            ):  # segments intersect has no hints option.
                 self.assertIn("trace | ", question)
                 self.assertIn("initial_trace:", question)
                 self.assertIn("trace | ", text)

--- a/clrs/_src/clrs_text/huggingface_generators_test.py
+++ b/clrs/_src/clrs_text/huggingface_generators_test.py
@@ -1,0 +1,60 @@
+"""Tests for clrs._src.clrs_text.huggingface_generators."""
+from absl.testing import parameterized
+import clrs
+from clrs._src.clrs_text import clrs_utils, huggingface_generators
+from datasets import Dataset, IterableDataset, Value, Features
+
+class TestFormatCLRSExamplesHFDataset(parameterized.TestCase):
+  """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py"""
+  @parameterized.product(
+      algo_name = list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
+      lengths = [[16], [16, 32]],
+      use_hints = [True, False],
+  )
+  def test_format(self, algo_name, lengths, use_hints):
+    """Test that we can format samples from any algo into strings from a hf Dataset."""
+    algs = {algo_name: lengths}
+    ds = Dataset.from_generator(huggingface_generators.clrs_gen, gen_kwargs={"algs": algs, "num_samples": 100, "use_hints": use_hints})
+
+    for sample in ds:
+      question, answer = sample['question'], sample['answer']
+
+      self.assertTrue(question.startswith(f'{algo_name}:\n'))
+      self.assertTrue(question.endswith(':\n'))
+      self.assertTrue(answer.endswith('\n\n'))
+
+      if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+        self.assertIn('trace | ', question)
+        self.assertIn('initial_trace:', question)
+      else:
+        self.assertNotIn('trace | ', question)
+        self.assertNotIn('initial_trace:', question)
+
+
+class TestFormatCLRSExamplesHFIterableDataset(parameterized.TestCase):
+  """Based on TestFormatCLRSExamples in clrs.src_.clrs_text.clrs_utils_test.py"""
+  @parameterized.product(
+      algo_name = list(clrs.CLRS_30_ALGS_SETTINGS.keys()),
+      lengths = [[16], [16, 32]],
+      use_hints = [True, False],
+  )
+  def test_format(self, algo_name, lengths, use_hints):
+    """Test that we can format samples from any algo into strings from a hf IterableDataset."""
+    algs = {algo_name: lengths}
+    ds = IterableDataset.from_generator(huggingface_generators.clrs_gen_inf, features=Features({'question': Value(dtype='string', id=None), 'answer': Value(dtype='string', id=None)}), gen_kwargs={"algs": algs, "use_hints": use_hints})
+
+    ds_iterator = iter(ds)
+    for _ in range(100): # only test 100 samples as we have infinite sampling on
+      sample = next(ds_iterator)
+      question, answer = sample['question'], sample['answer']
+
+      self.assertTrue(question.startswith(f'{algo_name}:\n'))
+      self.assertTrue(question.endswith(':\n'))
+      self.assertTrue(answer.endswith('\n\n'))
+
+      if use_hints and algo_name in clrs_utils.CLRS_TASKS_WITH_HINTS:
+        self.assertIn('trace | ', question)
+        self.assertIn('initial_trace:', question)
+      else:
+        self.assertNotIn('trace | ', question)
+        self.assertNotIn('initial_trace:', question)


### PR DESCRIPTION
Adding Huggingface Datasets `.from_generator` support to allow for CLRS-Text datasets to be easily converted to huggingface format.